### PR TITLE
Convenience methods + Fixes + Tests

### DIFF
--- a/Attributed/Operators.swift
+++ b/Attributed/Operators.swift
@@ -12,7 +12,7 @@ public func + (lhs: NSAttributedString, rhs: NSAttributedString) -> NSAttributed
     let result = NSMutableAttributedString()
     result.append(lhs)
     result.append(rhs)
-    return result
+    return NSAttributedString(attributedString: result)
 }
 
 

--- a/Attributed/String+Attributed.swift
+++ b/Attributed/String+Attributed.swift
@@ -182,3 +182,23 @@ extension NSString {
     }
 
 }
+
+
+extension NSAttributedString {
+
+    public func modified(with attributes: Attributes, for range: NSRange) -> NSAttributedString {
+        let result = NSMutableAttributedString(attributedString: self)
+        result.add(attributes, to: range)
+        return NSAttributedString(attributedString: result)
+    }
+
+}
+
+
+extension NSMutableAttributedString {
+
+    public func add(_ attributes: Attributes, to range: NSRange) {
+        self.addAttributes(attributes.dictionary, range: range)
+    }
+
+}

--- a/Attributed/String+Attributed.swift
+++ b/Attributed/String+Attributed.swift
@@ -169,3 +169,16 @@ extension String {
         return attributed(with: attributes)
     }
 }
+
+
+extension NSString {
+
+    public func attributed(with attributes: Attributes) -> NSAttributedString {
+        return (self as String).attributed(with: attributes)
+    }
+
+    public func attributed(_ attributeBlock: (Attributes) -> (Attributes)) -> NSAttributedString {
+        return (self as String).attributed(attributeBlock)
+    }
+
+}

--- a/AttributedTests/StringExtensionTests.swift
+++ b/AttributedTests/StringExtensionTests.swift
@@ -12,3 +12,36 @@ import XCTest
 class StringExtensionTests: XCTestCase {
     // TODO: Write Tests
 }
+
+
+final class NSStringExtensionTests: XCTestCase {
+
+    func testAttributedWithAttributes() {
+        let string = "😎 Lorem 😀 ipsum 👀 dolor 👻 sit 🎲 amet, 🎲 consectetur 🔥 adipiscing 🚀 elit." as  NSString
+        let attributes = Attributes {
+            $0.font(.systemFont(ofSize: 12.0))
+                .foreground(color: .darkGray)
+        }
+        let expected = NSAttributedString(string: (string as String), attributes: attributes.dictionary)
+        let attributed = string.attributed(with: attributes)
+        XCTAssertEqual(expected, attributed)
+
+        let attributed2 = string.attributed(with: attributes.foreground(color: .red))
+        XCTAssertNotEqual(expected, attributed2)
+    }
+
+    func testAttributedWithAttributeBlock() {
+        let string = "😎 Lorem 😀 ipsum 👀 dolor 👻 sit 🎲 amet, 🎲 consectetur 🔥 adipiscing 🚀 elit." as  NSString
+        let attributesBlock: ((Attributes) -> Attributes) = {
+            $0.font(.systemFont(ofSize: 12.0))
+                .foreground(color: .darkGray)
+        }
+        let expected = NSAttributedString(string: (string as String), attributes: attributesBlock(Attributes()).dictionary)
+        let attributed = string.attributed(attributesBlock)
+        XCTAssertEqual(expected, attributed)
+
+        let attributed2 = string.attributed { $0.foreground(color: .red) }
+        XCTAssertNotEqual(expected, attributed2)
+    }
+
+}

--- a/AttributedTests/StringExtensionTests.swift
+++ b/AttributedTests/StringExtensionTests.swift
@@ -9,8 +9,37 @@
 import XCTest
 @testable import Attributed
 
-class StringExtensionTests: XCTestCase {
-    // TODO: Write Tests
+
+final class StringExtensionTests: XCTestCase {
+
+    func testAttributedWithAttributes() {
+        let string = "😎 Lorem 😀 ipsum 👀 dolor 👻 sit 🎲 amet, 🎲 consectetur 🔥 adipiscing 🚀 elit."
+        let attributes = Attributes {
+            $0.font(.systemFont(ofSize: 12.0))
+                .foreground(color: .darkGray)
+        }
+        let expected = NSAttributedString(string: string, attributes: attributes.dictionary)
+        let attributed = string.attributed(with: attributes)
+        XCTAssertEqual(expected, attributed)
+
+        let attributed2 = string.attributed(with: attributes.foreground(color: .red))
+        XCTAssertNotEqual(expected, attributed2)
+    }
+
+    func testAttributedWithAttributeBlock() {
+        let string = "😎 Lorem 😀 ipsum 👀 dolor 👻 sit 🎲 amet, 🎲 consectetur 🔥 adipiscing 🚀 elit."
+        let attributesBlock: ((Attributes) -> Attributes) = {
+            $0.font(.systemFont(ofSize: 12.0))
+                .foreground(color: .darkGray)
+        }
+        let expected = NSAttributedString(string: string, attributes: attributesBlock(Attributes()).dictionary)
+        let attributed = string.attributed(attributesBlock)
+        XCTAssertEqual(expected, attributed)
+
+        let attributed2 = string.attributed { $0.foreground(color: .red) }
+        XCTAssertNotEqual(expected, attributed2)
+    }
+
 }
 
 

--- a/AttributedTests/StringExtensionTests.swift
+++ b/AttributedTests/StringExtensionTests.swift
@@ -45,3 +45,51 @@ final class NSStringExtensionTests: XCTestCase {
     }
 
 }
+
+
+final class NSAttributedStringExtensionTests: XCTestCase {
+
+    func testModifiedWithAttributesForRange() {
+        let string = "😎 Lorem 😀 ipsum 👀 dolor 👻 sit 🎲 amet, 🎲 consectetur 🔥 adipiscing 🚀 elit."
+        let range = (string as NSString).range(of: "👻 sit 🎲 amet, 🎲 consectetur")
+        let attributes = Attributes {
+            $0.font(.systemFont(ofSize: 12.0))
+                .foreground(color: .darkGray)
+        }
+        let rangeAttributes = Attributes().foreground(color: .red)
+        let expected = NSMutableAttributedString(string: (string as String), attributes: attributes.dictionary)
+        expected.addAttributes(rangeAttributes.dictionary, range: range)
+        let attributed = NSAttributedString(string: (string as String), attributes: attributes.dictionary)
+        XCTAssertNotEqual(expected.copy() as! NSAttributedString, attributed)
+        XCTAssertEqual(expected.copy() as! NSAttributedString, attributed.modified(with: rangeAttributes, for: range))
+
+        // Test againts + operator
+        let appended = "😎 Lorem 😀 ipsum 👀 dolor ".attributed(with: attributes)
+            + "👻 sit 🎲 amet, 🎲 consectetur".attributed(with: attributes + rangeAttributes)
+            + " 🔥 adipiscing 🚀 elit.".attributed(with: attributes)
+        XCTAssertEqual(appended, attributed.modified(with: rangeAttributes, for: range))
+    }
+
+}
+
+
+final class NSMutableAttributedStringExtensionTests: XCTestCase {
+
+    func testAddAttributesToRange() {
+        let string = "😎 Lorem 😀 ipsum 👀 dolor 👻 sit 🎲 amet, 🎲 consectetur 🔥 adipiscing 🚀 elit."
+        let range = (string as NSString).range(of: "👻 sit 🎲 amet, 🎲 consectetur")
+        let attributes = Attributes {
+            $0.font(.systemFont(ofSize: 12.0))
+                .foreground(color: .darkGray)
+        }
+        let rangeAttributes = Attributes().foreground(color: .red)
+        let expected = NSMutableAttributedString(string: (string as String), attributes: attributes.dictionary)
+        let attributed = NSMutableAttributedString(string: (string as String), attributes: attributes.dictionary)
+
+        expected.addAttributes(rangeAttributes.dictionary, range: range)
+        XCTAssertNotEqual(expected, attributed)
+        attributed.add(rangeAttributes, to: range)
+        XCTAssertEqual(expected, attributed)
+    }
+
+}


### PR DESCRIPTION
I have added a convenient way to add attributes to a specific range of a `NSAttributedString`.

The motivation for this work is for a use case where you might not be able to combine the attributed strings when creating it. For example lets say you have a long string that is localized and you want to change the style of a word within this string, although with localization the range is likely to change at runtime. e.g.:

```swift
let base = Attributes { $0.font(.systemFont(ofSize: UIFont.systemFontSize)) }
let bold = Attributes { $0.font(.boldSystemFont(ofSize: UIFont.systemFontSize)) }
let s = NSLocalizedString("Lorem ipsum dolor sit amet...", comment: "")
let r = (s as NSString).range(of: NSLocalizedString("ipsum dolor", comment: ""))
let attr = s
    .attributed(with: base)
    .modified(with: bold, for: r)
```

The work in this PR doesn't fully cover issue https://github.com/Nirma/Attributed/issues/11, although it does solves a similar issue.