### PR TITLE
Move extensions over into Attributed protocol extensions.

### DIFF
--- a/Attributed.xcodeproj/project.pbxproj
+++ b/Attributed.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AA3150381EA4A57300A86368 /* Attributed.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3150371EA4A57300A86368 /* Attributed.swift */; };
 		AA4B73E11E0B798C004C6947 /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4B73E01E0B798C004C6947 /* StringExtensionTests.swift */; };
 		AABEF4EC1E98F532003260B7 /* NSString+Attributed.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABEF4EB1E98F532003260B7 /* NSString+Attributed.swift */; };
 		AABEF4EE1E98F62C003260B7 /* Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABEF4ED1E98F62C003260B7 /* Attributes.swift */; };
@@ -28,6 +29,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		AA3150371EA4A57300A86368 /* Attributed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Attributed.swift; sourceTree = "<group>"; };
 		AA4B73E01E0B798C004C6947 /* StringExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
 		AABEF4EB1E98F532003260B7 /* NSString+Attributed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSString+Attributed.swift"; sourceTree = "<group>"; };
 		AABEF4ED1E98F62C003260B7 /* Attributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Attributes.swift; sourceTree = "<group>"; };
@@ -60,13 +62,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		AABEF4EF1E98F696003260B7 /* Attributes */ = {
+		AABEF4EF1E98F696003260B7 /* Attributed */ = {
 			isa = PBXGroup;
 			children = (
 				AABEF4ED1E98F62C003260B7 /* Attributes.swift */,
 				AAEE62871DF8F3BE0079C70C /* Operators.swift */,
+				AA3150371EA4A57300A86368 /* Attributed.swift */,
 			);
-			name = Attributes;
+			name = Attributed;
 			sourceTree = "<group>";
 		};
 		AABEF4F01E98F6C6003260B7 /* Extensions */ = {
@@ -116,7 +119,7 @@
 		AAEE626F1DF8F3690079C70C /* Attributed */ = {
 			isa = PBXGroup;
 			children = (
-				AABEF4EF1E98F696003260B7 /* Attributes */,
+				AABEF4EF1E98F696003260B7 /* Attributed */,
 				AABEF4F01E98F6C6003260B7 /* Extensions */,
 				AABEF4F11E98F700003260B7 /* Supporting Files */,
 			);
@@ -248,6 +251,7 @@
 				AABEF4EC1E98F532003260B7 /* NSString+Attributed.swift in Sources */,
 				AABEF4EE1E98F62C003260B7 /* Attributes.swift in Sources */,
 				AAEE62881DF8F3BE0079C70C /* Operators.swift in Sources */,
+				AA3150381EA4A57300A86368 /* Attributed.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Attributed/Attributed.swift
+++ b/Attributed/Attributed.swift
@@ -1,0 +1,56 @@
+//
+//  Attributed.swift
+//  Attributed
+//
+//  Created by Nicholas Maccharoli on 2017/04/17.
+//  Copyright © 2017年 Attributed. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+
+/**
+ Features that exist in Attributed are written as extensions to this class `Attributed`.
+ */
+
+public final class Attributed<Base> {
+    let base: Base
+    public init(_ base: Base) {
+        self.base = base
+    }
+}
+
+
+/**
+ Types that have Attributed extensions extend `AttributedCompatible`.
+ */
+
+public protocol AttributedCompatible {
+    associatedtype CompatibleType
+
+    var at: CompatibleType { get }
+}
+
+public extension AttributedCompatible {
+    public var at: Attributed<Self> {
+        return Attributed(self)
+    }
+}
+
+
+/**
+ Types that wish to implement Attributed extensions should adapt `AttributedCompatible` first 
+ and then write extensions in the format of: 
+    
+    `extension Attributed where Base == SomeType { ... }`
+ 
+ The merit of adapting the `AttributedCompatible` protocol
+ is that methods defined in this mannor are grouped under their own `at` namespace, therefore the chance 
+ of naming collisions is lower and when reading through code that uses the attributed library it is clear 
+ what is an extension that Attributed provides and what is not.
+ */
+
+extension String: AttributedCompatible { }
+extension NSString: AttributedCompatible { }
+extension NSAttributedString: AttributedCompatible { }

--- a/Attributed/Attributes.swift
+++ b/Attributed/Attributes.swift
@@ -69,7 +69,6 @@ public struct Attributes {
     }
 }
 
-
 // MARK: NSParagraphStyle related
 
 extension Attributes {

--- a/Attributed/NSString+Attributed.swift
+++ b/Attributed/NSString+Attributed.swift
@@ -8,14 +8,13 @@
 
 import Foundation
 
-extension NSString {
+extension Attributed where Base == NSString {
 
     public func attributed(with attributes: Attributes) -> NSAttributedString {
-        return (self as String).attributed(with: attributes)
+        return attributed(with: attributes)
     }
 
     public func attributed(_ attributeBlock: (Attributes) -> (Attributes)) -> NSAttributedString {
-        return (self as String).attributed(attributeBlock)
+        return attributed(attributeBlock)
     }
-
 }

--- a/Attributed/String+Attributed.swift
+++ b/Attributed/String+Attributed.swift
@@ -9,14 +9,13 @@
 import Foundation
 import UIKit
 
-
 // MARK: Primary Extension
 
-extension String {
+extension Attributed where Base == String {
 
     public func attributed(with attributes: Attributes) -> NSAttributedString {
         let attributes = attributes.dictionary
-        return NSAttributedString(string: self, attributes: attributes)
+        return NSAttributedString(string: base, attributes: attributes)
     }
 
     public func attributed(_ attributeBlock: (Attributes) -> (Attributes)) -> NSAttributedString {
@@ -25,20 +24,21 @@ extension String {
     }
 }
 
-extension NSAttributedString {
+public extension Attributed where Base == NSMutableAttributedString {
 
-    public func modified(with attributes: Attributes, for range: NSRange) -> NSAttributedString {
-        let result = NSMutableAttributedString(attributedString: self)
-        result.add(attributes, to: range)
-        return NSAttributedString(attributedString: result)
+    public func add(_ attributes: Attributes, to range: NSRange) {
+        base.addAttributes(attributes.dictionary, range: range)
     }
 
 }
 
-extension NSMutableAttributedString {
+public extension Attributed where Base == NSAttributedString {
 
-    public func add(_ attributes: Attributes, to range: NSRange) {
-        addAttributes(attributes.dictionary, range: range)
+    public func modified(with attributes: Attributes, for range: NSRange) -> NSAttributedString {
+        let string = base as NSAttributedString
+
+        let result = NSMutableAttributedString(attributedString: string)
+        result.at.add(attributes, to: range)
+        return NSAttributedString(attributedString: result)
     }
-
 }

--- a/AttributedTests/StringExtensionTests.swift
+++ b/AttributedTests/StringExtensionTests.swift
@@ -19,10 +19,10 @@ final class StringExtensionTests: XCTestCase {
                 .foreground(color: .darkGray)
         }
         let expected = NSAttributedString(string: string, attributes: attributes.dictionary)
-        let attributed = string.attributed(with: attributes)
+        let attributed = string.at.attributed(with: attributes)
         XCTAssertEqual(expected, attributed)
 
-        let attributed2 = string.attributed(with: attributes.foreground(color: .red))
+        let attributed2 = string.at.attributed(with: attributes.foreground(color: .red))
         XCTAssertNotEqual(expected, attributed2)
     }
 
@@ -33,10 +33,10 @@ final class StringExtensionTests: XCTestCase {
                 .foreground(color: .darkGray)
         }
         let expected = NSAttributedString(string: string, attributes: attributesBlock(Attributes()).dictionary)
-        let attributed = string.attributed(attributesBlock)
+        let attributed = string.at.attributed(attributesBlock)
         XCTAssertEqual(expected, attributed)
 
-        let attributed2 = string.attributed { $0.foreground(color: .red) }
+        let attributed2 = string.at.attributed { $0.foreground(color: .red) }
         XCTAssertNotEqual(expected, attributed2)
     }
 
@@ -52,10 +52,10 @@ final class NSStringExtensionTests: XCTestCase {
                 .foreground(color: .darkGray)
         }
         let expected = NSAttributedString(string: (string as String), attributes: attributes.dictionary)
-        let attributed = string.attributed(with: attributes)
+        let attributed = (string as String).at.attributed(with: attributes)
         XCTAssertEqual(expected, attributed)
 
-        let attributed2 = string.attributed(with: attributes.foreground(color: .red))
+        let attributed2 = (string as String).at.attributed(with: attributes.foreground(color: .red))
         XCTAssertNotEqual(expected, attributed2)
     }
 
@@ -66,10 +66,10 @@ final class NSStringExtensionTests: XCTestCase {
                 .foreground(color: .darkGray)
         }
         let expected = NSAttributedString(string: (string as String), attributes: attributesBlock(Attributes()).dictionary)
-        let attributed = string.attributed(attributesBlock)
+        let attributed = (string as String).at.attributed(attributesBlock)
         XCTAssertEqual(expected, attributed)
 
-        let attributed2 = string.attributed { $0.foreground(color: .red) }
+        let attributed2 = (string as String).at.attributed { $0.foreground(color: .red) }
         XCTAssertNotEqual(expected, attributed2)
     }
 
@@ -90,13 +90,14 @@ final class NSAttributedStringExtensionTests: XCTestCase {
         expected.addAttributes(rangeAttributes.dictionary, range: range)
         let attributed = NSAttributedString(string: (string as String), attributes: attributes.dictionary)
         XCTAssertNotEqual(expected.copy() as! NSAttributedString, attributed)
-        XCTAssertEqual(expected.copy() as! NSAttributedString, attributed.modified(with: rangeAttributes, for: range))
+
+        XCTAssertEqual(expected.copy() as! NSAttributedString, attributed.at.modified(with: rangeAttributes, for: range))
 
         // Test againts + operator
-        let appended = "😎 Lorem 😀 ipsum 👀 dolor ".attributed(with: attributes)
-            + "👻 sit 🎲 amet, 🎲 consectetur".attributed(with: attributes + rangeAttributes)
-            + " 🔥 adipiscing 🚀 elit.".attributed(with: attributes)
-        XCTAssertEqual(appended, attributed.modified(with: rangeAttributes, for: range))
+        let appended = "😎 Lorem 😀 ipsum 👀 dolor ".at.attributed(with: attributes)
+            + "👻 sit 🎲 amet, 🎲 consectetur".at.attributed(with: attributes + rangeAttributes)
+            + " 🔥 adipiscing 🚀 elit.".at.attributed(with: attributes)
+        XCTAssertEqual(appended, attributed.at.modified(with: rangeAttributes, for: range))
     }
 
 }
@@ -117,7 +118,7 @@ final class NSMutableAttributedStringExtensionTests: XCTestCase {
 
         expected.addAttributes(rangeAttributes.dictionary, range: range)
         XCTAssertNotEqual(expected, attributed)
-        attributed.add(rangeAttributes, to: range)
+        attributed.at.add(rangeAttributes, to: range)
         XCTAssertEqual(expected, attributed)
     }
 


### PR DESCRIPTION
The purpose of this pull request is to refactor the way extensions are written in Attributed.

Instead of writing extensions directly, extensions are written and accessed with a namespace like prefix, in this case `at` as in: `"some awesome string".at.attributed(with: attributes)` instead of calling `attributed(with:)` directly on `String` as in `"some awesome string".at.attributed(with: attributes)`

I think for the most part after merging this pull request the codebase will become cleaner.