### PR TITLE
Fix crash on underline

### DIFF
--- a/Attributed/Attributes.swift
+++ b/Attributed/Attributes.swift
@@ -53,7 +53,7 @@ public struct Attributes {
     }
 
     public func underlineStyle(_ underlineStyle: NSUnderlineStyle) -> Attributes {
-        return self + Attributes(dictionary: [NSAttributedStringKey.underlineStyle: underlineStyle])
+        return self + Attributes(dictionary: [NSAttributedStringKey.underlineStyle: underlineStyle.rawValue])
     }
 
     public func strokeColor(_ strokeColor: UIColor) -> Attributes {


### PR DESCRIPTION
Crash on swift 4 :
https://stackoverflow.com/questions/46092027/setting-nsunderlinestyle-causes-unrecogognized-selector-exception