### PR TITLE
Update AttributedLib.podspec

### DIFF
--- a/AttributedLib.podspec
+++ b/AttributedLib.podspec
@@ -17,7 +17,7 @@ to `NSAttributedString`.
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Nicholas Maccharoli' => 'nmaccharoli@gmail.com' }
   s.source           = { :git => 'https://github.com/Nirma/Attributed.git', :tag => s.version.to_s }
- 
+  s.swift_version    = '5.0'
   s.ios.deployment_target = '9.0'
   s.source_files = 'Attributed/*.swift'
  


### PR DESCRIPTION
Cocoapods-Rome requires SWIFT_VERSION in order to build the framework

otherwise it will raise error like this

```
[!] Unable to determine Swift version for the following pods:

- `AttributedLib` does not specify a Swift version and none of the targets (`App`) integrating it have the `SWIFT_VERSION` attribute set. Please contact the author or set the `SWIFT_VERSION` attribute in at least one of the targets that integrate this pod.
```